### PR TITLE
Fix build issues with DMAS weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ Fill in a plantnet API key.
 
 ## Running
 
+DMAS requires trained weights to work.
+These use the human detection dataset available at: https://www.kaggle.com/datasets/constantinwerner/human-detection-dataset.
+Download this and extract it to DMAS/models/human_detection/datasets/human_detection_dataset.
+Then, to train the model, run the following commands.
+```
+$ cd DMAS
+$ python3 -m venv venv
+$ . venv/bin/activate (linux) or ./venv/Scripts/activate (win)
+$ pip install -r requirements.txt
+$ cd models/human_detection
+$ python3 human_detector.py 
+```
+
 ```
 $ docker-compose up -d
 # or to only run specific components (in this case DB and DMAS)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
     ports:
       - "8081:8080"
     volumes:
-      - ./dmas_config.ini:/config.ini
+      - ./dmas_config.ini:/app/config.ini
+      - ./DMAS/models/human_detection/weights/human_classification_weights.pkl:/app/models/human_detection/weights/human_classification_weights.pkl
     environment:
       CONFIG_FILE: "/config.ini"
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - "8081:8080"
     volumes:
       - ./dmas_config.ini:/app/config.ini
-      - ./DMAS/models/human_detection/weights/human_classification_weights.pkl:/app/models/human_detection/weights/human_classification_weights.pkl
     environment:
       CONFIG_FILE: "/config.ini"
   frontend:


### PR DESCRIPTION
Added instructions on how to create weights for the human detector model. I don't think these are copied into the container though as I get the following error in the DMAS container when I run docker compose:

```
FileNotFoundError: [Errno 2] No such file or directory: 'weights/human_classification_weights.pkl'
```

Do any docker wizards know how to fix this? 